### PR TITLE
Генерация документации грамматики из yacc

### DIFF
--- a/OLang/Compiler/Parser/GrammarYaac.y
+++ b/OLang/Compiler/Parser/GrammarYaac.y
@@ -54,7 +54,6 @@
 %token STRING
 
 %%
-
 Program
     : ClassDeclarations { $$ = CreateProgram($1); }
     ;
@@ -168,7 +167,7 @@ ElseTail
     | ELSE Body { $$ = $2; }
     ;
 
-// TODO: мейби вынести, как на паре показывали (но хочется посмотреть самому на конфликты)
+// TODO: пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ, пїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ (пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅ пїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ)
 ReturnStatement
     : RETURN { $$ = CreateReturn(null); }
     | RETURN Expression { $$ = CreateReturn($2); }
@@ -199,7 +198,7 @@ Arguments
     | Arguments COMMA Expression { AddToList($$, $3); $$ = $1; }
     ;
 
-// TODO: не знаю, что нужны ли Scanner.yylval -- надо будет проверить
+// TODO: пїЅпїЅ пїЅпїЅпїЅпїЅ, пїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅ Scanner.yylval -- пїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅ пїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅпїЅ
 Primary
     : INTEGER
     | REAL
@@ -209,5 +208,4 @@ Primary
     | ClassName
     | SUPER
     ;
-
 %%

--- a/OLang/GenerateGrammarDocs.csx
+++ b/OLang/GenerateGrammarDocs.csx
@@ -1,0 +1,74 @@
+using System.IO;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+string yaccPath = Path.Combine("Compiler", "Parser", "GrammarYaac.y");
+string docPath = Path.Combine("..", "docs", "grammar.md");
+
+Dictionary<string, string> tokens = new()
+{
+    ["CLASS"] = "class",
+    ["EXTENDS"] = "extends",
+    ["LET"] = "let",
+    ["THIS"] = "this",
+    ["METHOD"] = "method",
+    ["IS"] = "is",
+    ["END"] = "end",
+    ["RETURN"] = "return",
+    ["WHILE"] = "while",
+    ["LOOP"] = "loop",
+    ["IF"] = "if",
+    ["THEN"] = "then",
+    ["ELSE"] = "else",
+    ["COMMA"] = ",",
+    ["COLON"] = ":",
+    ["SEMICOLON"] = ";",
+    ["LPARENT"] = "(",
+    ["RPARENT"] = ")",
+    ["LBRACKET"] = "[",
+    ["RBRACKET"] = "]",
+    ["DOT"] = ".",
+    ["ASAN"] = "=",
+    ["FIELD"] = "field",
+    ["STATIC"] = "static",
+    ["FUNCTION"] = "function",
+    ["SUPER"] = "super"
+};
+
+if (File.Exists(yaccPath))
+{
+    if (!File.Exists(docPath))
+    {
+        File.Create(docPath).Close();
+    }
+
+    using StreamWriter writer = new(docPath);
+    using StreamReader reader = new(yaccPath);
+
+    bool inside = false;
+
+    while (!reader.EndOfStream)
+    {
+        string line = reader.ReadLine();
+        
+        if (line == "%%")
+        {
+            inside = !inside;
+        }
+        else if (inside)
+        {
+            line = Regex.Replace(line, @"\{.*?\}", "");
+
+            foreach (var pair in tokens)
+            {
+                line = Regex.Replace(line, $@"\b{pair.Key}\b", $"\"{pair.Value}\"");
+            }
+
+            writer.WriteLine(line);
+        }
+    }
+}
+else
+{
+    Console.WriteLine($"Yacc file {yaccPath} with grammar description was not found");
+}

--- a/OLang/OLang.csproj
+++ b/OLang/OLang.csproj
@@ -26,5 +26,8 @@
             <OutputFile>Compiler\Parser\Parser.Generated.cs</OutputFile>
         </YaccFile>
     </ItemGroup>
-
+    
+    <Target Name="GenerateGrammarDocs" BeforeTargets="Build">
+        <Exec Command="csi GenerateGrammarDocs.csx" />
+    </Target>
 </Project>


### PR DESCRIPTION
Во время сборки вызывается скрипт `GenerateGrammarDocs.csx`, который создает файл `docs/grammar.md` с упрощенным представлением грамматики из `GrammarYaac.y` (кажется, в названии этого файла опечатка).